### PR TITLE
install latest odoo version

### DIFF
--- a/tasks/debian/main.yml
+++ b/tasks/debian/main.yml
@@ -62,7 +62,7 @@
 - name: Odoo | Install database
   ansible.builtin.apt:
     name: ['postgresql', 'postgresql-client']
-    state: present
+    state: latest
   when: ODOO_CONFIG.manage.database | bool
 
 - name: Odoo | Install


### PR DESCRIPTION
If you update odoo to a new version, it will not "apply" the version number specified in the configuration variable. We might want to change apt module state from present to latest