### PR TITLE
Fix odoo service failing to start when no database installed locally

### DIFF
--- a/templates/etc/systemd/system/odoo.service.d/override.conf.j2
+++ b/templates/etc/systemd/system/odoo.service.d/override.conf.j2
@@ -2,7 +2,7 @@
 # ansibleguy.sw_odoo_community
 
 [Unit]
-Requires=postgresql.service
+{% if ODOO_CONFIG.manage.database %}Requires=postgresql.service{% endif %}
 Documentation=https://github.com/ansibleguy/sw_odoo_community
 
 [Service]


### PR DESCRIPTION
Templating postgres as dependency in service override to prevent service from failing if you do not need a postgres instance locally