### PR TITLE
Compile ODOO_CONFIG as fact

### DIFF
--- a/tasks/debian/main.yml
+++ b/tasks/debian/main.yml
@@ -4,7 +4,7 @@
   ansible.builtin.debug:
     var: odoo
   when: debug | bool
-  
+
 - name: Odoo | Set ODOO_CONFIG fact
   ansible.builtin.set_fact:
     ODOO_CONFIG: "{{ ODOO_CONFIG }}"

--- a/tasks/debian/main.yml
+++ b/tasks/debian/main.yml
@@ -4,6 +4,10 @@
   ansible.builtin.debug:
     var: odoo
   when: debug | bool
+  
+- name: Odoo | Set ODOO_CONFIG fact
+  ansible.builtin.set_fact:
+    ODOO_CONFIG: "{{ ODOO_CONFIG }}"
 
 - name: Odoo | Showing debug info - running config
   ansible.builtin.debug:


### PR DESCRIPTION
When trying to install on multiple hosts at the same time, role randomly fails on random tasks because it tries to evaluate the lookup statement at the same time, causing leading to lock on temp file of the playbook .

Evaluating once the lookup statement and set it as fact resolve this issue